### PR TITLE
Add missing schedule and news links

### DIFF
--- a/NaisoHP.html
+++ b/NaisoHP.html
@@ -320,6 +320,36 @@
                     <a href="BMC.html">BMC</a>
                     <div class="assignee">木野ST・神</div>
                 </div>
+                <div class="portal-item" onclick="window.location.href='file://tgfs1/ＩＥ開発部/00_ＩＥ開発部/BMC/調査結果/0_スケジュール管理/社外展示会_イベント一覧2025.xlsx%20-%20ショートカット.lnk'">
+                    <div class="icon-container">
+                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.9 20.1 3 19 3Z" fill="currentColor"/>
+                            <path d="M17 12H14V14H17V12ZM13 12H10V14H13V12ZM9 12H6V14H9V12Z" fill="currentColor"/>
+                            <path d="M17 9H14V11H17V9ZM13 9H10V11H13V9ZM9 9H6V11H9V9Z" fill="currentColor"/>
+                            <path d="M17 15H14V17H17V15ZM13 15H10V17H13V15ZM9 15H6V17H9V15Z" fill="currentColor"/>
+                            <path d="M21 7H3V5H21V7Z" fill="currentColor"/>
+                        </svg>
+                    </div>
+                    <div class="item-content">
+                        <a href="file://tgfs1/ＩＥ開発部/00_ＩＥ開発部/BMC/調査結果/0_スケジュール管理/社外展示会_イベント一覧2025.xlsx%20-%20ショートカット.lnk">展示会日程・レポート</a>
+                        <div class="item-owner">山田（智）</div>
+                    </div>
+                </div>
+                <div class="portal-item" onclick="window.location.href='file://tgfs1/ＩＥ開発部/01_内装開発室/01_個別開発テーマ/03_個別テーマ活動フォルダ/生成AI活用/ChatGPT/内装開発デイリーニュース/内装開発デイリーニュース%20-%20ショートカット.lnk'">
+                    <div class="icon-container">
+                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M4 6H20V8H4V6ZM4 11H20V13H4V11ZM4 16H20V18H4V16Z" fill="currentColor"/>
+                            <path d="M2 4V20C2 21.1 2.9 22 4 22H20C21.1 22 22 21.1 22 20V4C22 2.9 21.1 2 20 2H4C2.9 2 2 2.9 2 4Z" fill="none" stroke="currentColor" stroke-width="2"/>
+                            <circle cx="6" cy="7" r="1" fill="currentColor"/>
+                            <circle cx="6" cy="12" r="1" fill="currentColor"/>
+                            <circle cx="6" cy="17" r="1" fill="currentColor"/>
+                        </svg>
+                    </div>
+                    <div class="item-content">
+                        <a href="file://tgfs1/ＩＥ開発部/01_内装開発室/01_個別開発テーマ/03_個別テーマ活動フォルダ/生成AI活用/ChatGPT/内装開発デイリーニュース/内装開発デイリーニュース%20-%20ショートカット.lnk">内装開発デイリーニュース</a>
+                        <div class="item-owner">中村</div>
+                    </div>
+                </div>
                 <div class="portal-item" onclick="window.location.href='file://tgfs1/ＩＥ開発部/01_内装開発室/●日常管理リンク.xlsx'">
                     <div class="icon-container icon-tools">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- add exhibition schedule and daily news links to internal portal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879f142f4c08326929687cb348b16fc