### PR TITLE
Fix broken links for file access

### DIFF
--- a/BMC.html
+++ b/BMC.html
@@ -255,7 +255,7 @@
     <div class="status-badge">工事中</div>
     <div class="assignee">木野・神</div>
                 </div>
-                <div class="portal-item" onclick="window.location.href='file://tgfs1/ＩＥ開発部/00_ＩＥ開発部/BMC/調査結果/0_スケジュール管理/社外展示会_イベント一覧2025.xlsx'">
+                <div class="portal-item" onclick="window.location.href='ms-excel:ofe|u|file://tgfs1/ＩＥ開発部/00_ＩＥ開発部/BMC/調査結果/0_スケジュール管理/社外展示会_イベント一覧2025.xlsx'">
                     <div class="icon-container">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.9 20.1 3 19 3Z" fill="currentColor"/>
@@ -265,10 +265,10 @@
                             <path d="M21 7H3V5H21V7Z" fill="currentColor"/>
                         </svg>
                     </div>
-                        <a href="file://tgfs1/ＩＥ開発部/00_ＩＥ開発部/BMC/調査結果/0_スケジュール管理/社外展示会_イベント一覧2025.xlsx">展示会日程・レポート</a>
+                        <a href="ms-excel:ofe|u|file://tgfs1/ＩＥ開発部/00_ＩＥ開発部/BMC/調査結果/0_スケジュール管理/社外展示会_イベント一覧2025.xlsx" target="_blank">展示会日程・レポート</a>
                         <div class="assignee">山田（智）</div>
                 </div>
-                <div class="portal-item" onclick="window.location.href='file://tgfs1/ＩＥ開発部/01_内装開発室/01_個別開発テーマ/03_個別テーマ活動フォルダ/生成AI活用/ChatGPT/内装開発デイリーニュース'">
+                <div class="portal-item" onclick="window.location.href='file://tgfs1/ＩＥ開発部/01_内装開発室/01_個別開発テーマ/03_個別テーマ活動フォルダ/生成AI活用/ChatGPT/内装開発デイリーニュース/'">
                     <div class="icon-container">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M4 6H20V8H4V6ZM4 11H20V13H4V11ZM4 16H20V18H4V16Z" fill="currentColor"/>
@@ -278,7 +278,7 @@
                             <circle cx="6" cy="17" r="1" fill="currentColor"/>
                         </svg>
                     </div>
-                        <a href="file://tgfs1/ＩＥ開発部/01_内装開発室/01_個別開発テーマ/03_個別テーマ活動フォルダ/生成AI活用/ChatGPT/内装開発デイリーニュース">内装開発デイリーニュース</a>
+                        <a href="file://tgfs1/ＩＥ開発部/01_内装開発室/01_個別開発テーマ/03_個別テーマ活動フォルダ/生成AI活用/ChatGPT/内装開発デイリーニュース/" target="_blank">内装開発デイリーニュース</a>
                         <div class="assignee">中村</div>
                 </div>
             </div>

--- a/NaisoHP.html
+++ b/NaisoHP.html
@@ -261,14 +261,14 @@
         <div class="portal-column">
             <div class="portal-title">全社用</div>
             <div class="portal-grid">
-                <div class="portal-item" onclick="window.location.href='http://tgnet/sites/portal/ied/Shared%20Documents/%E5%86%85%E8%A3%85%E9%96%8B%E7%99%BA%E5%AE%A4%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6.pptx'">
+                <div class="portal-item" onclick="window.location.href='ms-powerpoint:ofe|u|http://tgnet/sites/portal/ied/Shared%20Documents/%E5%86%85%E8%A3%85%E9%96%8B%E7%99%BA%E5%AE%A4%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6.pptx'">
                     <div class="icon-container icon-person">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" fill="currentColor"/>
                             <path d="M12 14C7.58172 14 4 17.5817 4 22H20C20 17.5817 16.4183 14 12 14Z" fill="currentColor"/>
                         </svg>
                     </div>
-                    <a href="http://tgnet/sites/portal/ied/Shared%20Documents/%E5%86%85%E8%A3%85%E9%96%8B%E7%99%BA%E5%AE%A4%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6.pptx">内装開発室について</a>
+                    <a href="ms-powerpoint:ofe|u|http://tgnet/sites/portal/ied/Shared%20Documents/%E5%86%85%E8%A3%85%E9%96%8B%E7%99%BA%E5%AE%A4%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6.pptx" target="_blank">内装開発室について</a>
                     <div class="assignee">山田S・木野ST</div>
                 </div>
                 <div class="portal-item" onclick="window.location.href='http://tgnet/sites/portal/ied/SitePages/%E7%B5%84%E7%B9%94%E8%A1%A8.aspx'">
@@ -288,7 +288,7 @@
         <div class="portal-column">
             <div class="portal-title internal">部内用</div>
             <div class="portal-grid">
-                <div class="portal-item" onclick="window.location.href='file://tgfs1/技術広報BtoB/2024/顧客向け展示会/04_パネル/＃3/内装_#3'">
+                <div class="portal-item" onclick="window.location.href='file://tgfs1/技術広報BtoB/2024/顧客向け展示会/04_パネル/＃3/内装_%233'">
                     <div class="icon-container icon-product">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M9 21C9 21.5523 9.44772 22 10 22H14C14.5523 22 15 21.5523 15 21V20H9V21Z" fill="currentColor"/>
@@ -296,7 +296,7 @@
                         </svg>
                     </div>
                     <div class="item-content">
-                        <a href="file://tgfs1/技術広報BtoB/2024/顧客向け展示会/04_パネル/＃3/内装_#3">開発品</a>
+                        <a href="file://tgfs1/技術広報BtoB/2024/顧客向け展示会/04_パネル/＃3/内装_%233" target="_blank">開発品</a>
                         <div class="assignee">各担当</div>
                     </div>
                 </div>
@@ -321,13 +321,13 @@
                     <a href="BMC.html">BMC</a>
                     <div class="assignee">木野ST・神</div>
                 </div>
-                <div class="portal-item" onclick="window.location.href='file://tgfs1/ＩＥ開発部/01_内装開発室/●日常管理リンク.xlsx'">
+                <div class="portal-item" onclick="window.location.href='ms-excel:ofe|u|file://tgfs1/ＩＥ開発部/01_内装開発室/●日常管理リンク.xlsx'">
                     <div class="icon-container icon-tools">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M22.7 19L13.6 9.9C14.5 7.6 14 4.9 12.1 3C10.1 1 7.1 0.6 4.7 1.7L9 6L6 9L1.6 4.7C0.4 7.1 0.9 10.1 2.9 12.1C4.8 14 7.5 14.5 9.8 13.6L18.9 22.7C19.3 23.1 19.9 23.1 20.3 22.7L22.6 20.4C23.1 20 23.1 19.3 22.7 19Z" fill="currentColor"/>
                         </svg>
                     </div>
-                    <a href="file://tgfs1/ＩＥ開発部/01_内装開発室/●日常管理リンク.xlsx">日常管理ツール</a>
+                    <a href="ms-excel:ofe|u|file://tgfs1/ＩＥ開発部/01_内装開発室/●日常管理リンク.xlsx" target="_blank">日常管理ツール</a>
                     <div class="assignee">野倉GL</div>
                 </div>
                 <div class="portal-item" onclick="window.location.href='http://172.29.45.232/panelist_db/'">


### PR DESCRIPTION
## Summary
- open interior development slides directly in PowerPoint
- encode special characters for the development items folder
- force Excel files to open instead of download
- ensure daily news folder opens in Explorer

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68808c0fcbfc832690cbe2e874cb4368